### PR TITLE
User-specific directories in /tmp

### DIFF
--- a/lib/DefaultFlags.py
+++ b/lib/DefaultFlags.py
@@ -4,7 +4,7 @@ License: Part of the PIRA project. Licensed under BSD 3 clause license. See LICE
 Description: Module holds a selection of default flags.
 """
 import typing
-
+import getpass
 
 class BackendDefaults:
   """
@@ -49,7 +49,7 @@ class BackendDefaults:
       return kwargs
 
     def get_wrap_w_file(self) -> str:
-      return '/tmp/pira-mpi-filter.w'
+      return '/tmp/' + getpass.getuser() + '-pira-mpi-filter.w'
 
     def get_wrap_c_file(self) -> str:
       return '/tmp/pira-mpi-filter.c'

--- a/lib/DefaultFlags.py
+++ b/lib/DefaultFlags.py
@@ -49,13 +49,13 @@ class BackendDefaults:
       return kwargs
 
     def get_wrap_w_file(self) -> str:
-      return '/tmp/' + getpass.getuser() + '-pira-mpi-filter.w'
+      return '/tmp/pira-' + getpass.getuser() + '/pira-mpi-filter.w'
 
     def get_wrap_c_file(self) -> str:
-      return '/tmp/pira-mpi-filter.c'
+      return '/tmp/pira-' + getpass.getuser() + '/pira-mpi-filter.c'
 
     def get_wrap_so_file(self) -> str:
-      return '/tmp/PIRA_MPI_Filter.so'
+      return '/tmp/pira-' + getpass.getuser() + '/PIRA_MPI_Filter.so'
 
     def get_MPI_wrap_LD_PRELOAD(self) -> str:
       return 'LD_PRELOAD=' + self.get_wrap_so_file()

--- a/lib/Measurement.py
+++ b/lib/Measurement.py
@@ -277,8 +277,7 @@ class ScorepSystemHelper:
   def prepare_MPI_filtering(cls, filter_file: str) -> None:
     # Find which MPI functions to filter
     # Get all MPI functions (our filter_file is a WHITELIST)
-    user = getpass.getuser()
-    mpi_funcs_dump = '/tmp/' + user + '_mpi_funcs.dump'
+    mpi_funcs_dump = '/tmp/pira-' + getpass.getuser() + '/mpi_funcs.dump'
     U.shell('wrap.py -d > ' + mpi_funcs_dump)
     all_MPI_functions_decls = U.read_file(mpi_funcs_dump).split('\n')
     all_MPI_functions = []

--- a/lib/Measurement.py
+++ b/lib/Measurement.py
@@ -11,7 +11,7 @@ from lib.Configuration import PiraConfiguration, TargetConfiguration, Instrument
 from lib.Exception import PiraException
 
 import typing
-
+import getpass
 
 class MeasurementSystemException(PiraException):
   """  This exception is thrown if problems in the runtime occur.  """
@@ -277,7 +277,8 @@ class ScorepSystemHelper:
   def prepare_MPI_filtering(cls, filter_file: str) -> None:
     # Find which MPI functions to filter
     # Get all MPI functions (our filter_file is a WHITELIST)
-    mpi_funcs_dump = '/tmp/mpi_funcs.dump'
+    user = getpass.getuser()
+    mpi_funcs_dump = '/tmp/' + user + '_mpi_funcs.dump'
     U.shell('wrap.py -d > ' + mpi_funcs_dump)
     all_MPI_functions_decls = U.read_file(mpi_funcs_dump).split('\n')
     all_MPI_functions = []

--- a/lib/Pira.py
+++ b/lib/Pira.py
@@ -21,7 +21,7 @@ from lib.Checker import Checker as checker
 
 import typing
 import sys
-
+import getpass
 
 def execute_with_config(runner: Runner, analyzer: A, pira_iters: int, target_config: TargetConfiguration) -> None:
   try:
@@ -134,6 +134,9 @@ def main(arguments) -> None:
 
   home_dir = U.get_cwd()
   U.set_home_dir(home_dir)
+
+  # FIXME the user should set this in config
+  U.make_dir('/tmp/pira-' + getpass.getuser())
 
   try:
     if arguments.config_version is 1:


### PR DESCRIPTION
Takes care of issues emerging from some runtime files being shared among PIRA instances of different users.
This is achieved by prepending the username to the name of the directory in `/tmp`, i.e., `/tmp/pira-<username>`.