### PR TITLE
adds command line option for directory containing runtime files

### DIFF
--- a/lib/Configuration.py
+++ b/lib/Configuration.py
@@ -515,3 +515,18 @@ class InvocationConfiguration:
 
   def get_num_repetitions(self) -> int:
     return self._num_repetitions
+
+class CSVConfiguration:
+
+  def __init__(self, csv_dir: str, csv_dialect: str):
+    self._csv_dir = csv_dir
+    self._csv_dialect = csv_dialect
+
+  def should_export(self) -> bool:
+    return self._csv_dir != ''
+
+  def get_csv_dir(self) -> str:
+    return self._csv_dir
+
+  def get_csv_dialect(self) -> str:
+    return self._csv_dialect

--- a/lib/Configuration.py
+++ b/lib/Configuration.py
@@ -487,8 +487,9 @@ class ExtrapConfiguration:
 
 class InvocationConfiguration:
 
-  def __init__(self, path_to_config: str, compile_time_filter: bool, pira_iters: int, num_reps: int, hybrid_filter_iters: int = 0):
+  def __init__(self, path_to_config: str, pira_dir: str,compile_time_filter: bool, pira_iters: int, num_reps: int, hybrid_filter_iters: int = 0):
     self._path_to_cfg = path_to_config
+    self._pira_dir = pira_dir
     self._compile_time_filtering = compile_time_filter
     self._pira_iters = pira_iters
     self._num_repetitions = num_reps
@@ -496,6 +497,9 @@ class InvocationConfiguration:
 
   def get_path_to_cfg(self) -> str:
     return self._path_to_cfg
+
+  def get_pira_dir(self) -> str:
+    return self._pira_dir
 
   def is_compile_time_filtering(self) -> bool:
     return self._compile_time_filtering

--- a/lib/Measurement.py
+++ b/lib/Measurement.py
@@ -85,6 +85,11 @@ class RunResult:
 
     return ovhds
 
+  def get_accumulated_runtime(self):
+    return self._accumulated_runtime
+
+  def get_nr_of_iterations(self):
+    return self._nr_of_iterations
 
 class ScorepSystemHelper:
   """  Takes care of setting necessary environment variables appropriately.  """

--- a/lib/Measurement.py
+++ b/lib/Measurement.py
@@ -11,7 +11,7 @@ from lib.Configuration import PiraConfiguration, TargetConfiguration, Instrument
 from lib.Exception import PiraException
 
 import typing
-import getpass
+import os
 
 class MeasurementSystemException(PiraException):
   """  This exception is thrown if problems in the runtime occur.  """
@@ -277,7 +277,8 @@ class ScorepSystemHelper:
   def prepare_MPI_filtering(cls, filter_file: str) -> None:
     # Find which MPI functions to filter
     # Get all MPI functions (our filter_file is a WHITELIST)
-    mpi_funcs_dump = '/tmp/pira-' + getpass.getuser() + '/mpi_funcs.dump'
+    default_provider = D.BackendDefaults()
+    mpi_funcs_dump = os.path.join(default_provider.instance.get_pira_dir(), 'mpi_funcs.dump')
     U.shell('wrap.py -d > ' + mpi_funcs_dump)
     all_MPI_functions_decls = U.read_file(mpi_funcs_dump).split('\n')
     all_MPI_functions = []

--- a/lib/Pira.py
+++ b/lib/Pira.py
@@ -89,9 +89,13 @@ def execute_with_config(runner: Runner, analyzer: A, pira_iters: int, target_con
       L.get_logger().log('[ITERTIME] $' + str(x) + '$ ' + str(user_time) + ', ' + str(system_time), level='perf')
 
     if(csv_config.should_export()):
-      file_name = target_config.get_place() + "_" +  target_config.get_build() + "_" + target_config.get_target() + "_" + target_config.get_flavor() + ".csv"
+      file_name = target_config.get_flavor() + ".csv"
       csv_file = os.path.join(csv_config.get_csv_dir(), file_name)
-      rr_exporter.export(csv_file, csv_config.get_csv_dialect())
+      try:
+        rr_exporter.export(csv_file, csv_config.get_csv_dialect())
+      except Exception as e:
+        L.get_logger().log(
+          'Pira::execute_with_config: Problem writing CSV file\nMessage:\n' + str(e), level='error')
 
   except Exception as e:
     L.get_logger().log(

--- a/lib/Pira.py
+++ b/lib/Pira.py
@@ -89,9 +89,10 @@ def execute_with_config(runner: Runner, analyzer: A, pira_iters: int, target_con
       L.get_logger().log('[ITERTIME] $' + str(x) + '$ ' + str(user_time) + ', ' + str(system_time), level='perf')
 
     if(csv_config.should_export()):
-      file_name = target_config.get_flavor() + ".csv"
+      file_name = target_config.get_build() + '_' + target_config.get_target() + '_' +  target_config.get_flavor() + '.csv'
       csv_file = os.path.join(csv_config.get_csv_dir(), file_name)
       try:
+        U.make_dir(csv_config.get_csv_dir())
         rr_exporter.export(csv_file, csv_config.get_csv_dialect())
       except Exception as e:
         L.get_logger().log(

--- a/lib/Pira.py
+++ b/lib/Pira.py
@@ -10,11 +10,13 @@ import lib.BatchSystemHelper as B
 import lib.FunctorManagement as F
 import lib.TimeTracking as T
 import lib.Database as D
+import lib.Exporter as E
 from lib.DefaultFlags import BackendDefaults
 from lib.RunnerFactory import PiraRunnerFactory
 from lib.ConfigurationLoader import SimplifiedConfigurationLoader as SCLoader
 from lib.ConfigurationLoader import ConfigurationLoader as CLoader
-from lib.Configuration import TargetConfiguration, PiraConfiguration, ExtrapConfiguration, InvocationConfiguration, PiraConfigurationErrorException
+from lib.Configuration import TargetConfiguration, PiraConfiguration, ExtrapConfiguration, InvocationConfiguration, \
+  PiraConfigurationErrorException, CSVConfiguration
 from lib.Runner import Runner, LocalRunner, LocalScalingRunner
 from lib.Builder import Builder as BU
 from lib.Analyzer import Analyzer as A
@@ -22,15 +24,18 @@ from lib.Checker import Checker as checker
 
 import typing
 import sys
-import getpass
+import os
 
-def execute_with_config(runner: Runner, analyzer: A, pira_iters: int, target_config: TargetConfiguration) -> None:
+def execute_with_config(runner: Runner, analyzer: A, pira_iters: int, target_config: TargetConfiguration, csv_config: CSVConfiguration) -> None:
   try:
     instrument = False
     pira_iterations = pira_iters
     hybrid_filtering = target_config.is_hybrid_filtering()
     compile_time_filtering = target_config.is_compile_time_filtering()
     hybrid_filter_iters = target_config.get_hybrid_filter_iters()
+
+    rr_exporter = E.RunResultExporter()
+
     # Build without any instrumentation
     L.get_logger().log('Building vanilla version for baseline measurements', level='info')
     vanilla_builder = BU(target_config, instrument)
@@ -44,6 +49,9 @@ def execute_with_config(runner: Runner, analyzer: A, pira_iters: int, target_con
         'Pira::execute_with_config: RunResult: ' + str(vanilla_rr) + ' | avg: ' + str(vanilla_rr.get_average()),
         level='debug')
     instr_file = ''
+
+    if (csv_config.should_export()):
+      rr_exporter.add_row('Vanilla', vanilla_rr)
 
     for x in range(0, pira_iterations):
       L.get_logger().log('Running instrumentation iteration ' + str(x), level='info')
@@ -68,6 +76,9 @@ def execute_with_config(runner: Runner, analyzer: A, pira_iters: int, target_con
       L.get_logger().log('Running profiling measurements', level='info')
       instr_rr = runner.do_profile_run(target_config, x)
 
+      if(csv_config.should_export()):
+        rr_exporter.add_row('Instrumented ' + str(x), instr_rr)
+
       # Compute overhead of instrumentation
       ovh_percentage = instr_rr.compute_overhead(vanilla_rr)
       L.get_logger().log('[RUNTIME] $' + str(x) + '$ ' + str(instr_rr.get_average()), level='perf')
@@ -76,6 +87,11 @@ def execute_with_config(runner: Runner, analyzer: A, pira_iters: int, target_con
       iteration_tracker.stop()
       user_time, system_time = iteration_tracker.get_time()
       L.get_logger().log('[ITERTIME] $' + str(x) + '$ ' + str(user_time) + ', ' + str(system_time), level='perf')
+
+    if(csv_config.should_export()):
+      file_name = target_config.get_place() + "_" +  target_config.get_build() + "_" + target_config.get_target() + "_" + target_config.get_flavor() + ".csv"
+      csv_file = os.path.join(csv_config.get_csv_dir(), file_name)
+      rr_exporter.export(csv_file, csv_config.get_csv_dialect())
 
   except Exception as e:
     L.get_logger().log(
@@ -126,6 +142,11 @@ def process_args_for_invoc(cmdline_args) -> None:
 
   return invoc_cfg
 
+def process_args_for_csv(cmdline_args):
+  csv_dir = cmdline_args.csv_dir
+  csv_dialect = cmdline_args.csv_dialect
+  csv_cfg = CSVConfiguration(csv_dir, csv_dialect)
+  return csv_cfg
 
 def main(arguments) -> None:
   """ Main function for pira framework. Used to invoke the various components. """
@@ -139,6 +160,8 @@ def main(arguments) -> None:
 
   U.make_dir(invoc_cfg.get_pira_dir())
   BackendDefaults(invoc_cfg)
+
+  csv_config = process_args_for_csv(arguments)
 
   try:
     if arguments.config_version is 1:
@@ -199,7 +222,7 @@ def main(arguments) -> None:
               t_config = TargetConfiguration(place, build, item, flavor, db_item_id, invoc_cfg.is_compile_time_filtering(), invoc_cfg.get_hybrid_filter_iters())
 
               # Execute using a local runner, given the generated target description
-              execute_with_config(runner, analyzer, invoc_cfg.get_pira_iters(), t_config)
+              execute_with_config(runner, analyzer, invoc_cfg.get_pira_iters(), t_config, csv_config)
 
           # If global flavor
           else:

--- a/lib/Pira.py
+++ b/lib/Pira.py
@@ -89,7 +89,7 @@ def execute_with_config(runner: Runner, analyzer: A, pira_iters: int, target_con
       L.get_logger().log('[ITERTIME] $' + str(x) + '$ ' + str(user_time) + ', ' + str(system_time), level='perf')
 
     if(csv_config.should_export()):
-      file_name = target_config.get_build() + '_' + target_config.get_target() + '_' +  target_config.get_flavor() + '.csv'
+      file_name = target_config.get_target() + '_' +  target_config.get_flavor() + '.csv'
       csv_file = os.path.join(csv_config.get_csv_dir(), file_name)
       try:
         U.make_dir(csv_config.get_csv_dir())

--- a/lib/Pira.py
+++ b/lib/Pira.py
@@ -10,6 +10,7 @@ import lib.BatchSystemHelper as B
 import lib.FunctorManagement as F
 import lib.TimeTracking as T
 import lib.Database as D
+from lib.DefaultFlags import BackendDefaults
 from lib.RunnerFactory import PiraRunnerFactory
 from lib.ConfigurationLoader import SimplifiedConfigurationLoader as SCLoader
 from lib.ConfigurationLoader import ConfigurationLoader as CLoader
@@ -114,13 +115,14 @@ def show_pira_invoc_info(cmdline_args) -> None:
 
 def process_args_for_invoc(cmdline_args) -> None:
   path_to_config = cmdline_args.config
+  pira_dir = cmdline_args.pira_dir
   compile_time_filter = not cmdline_args.runtime_filter
   hybrid_filter_iters = cmdline_args.hybrid_filter_iters
   pira_iters = cmdline_args.iterations
   num_reps = cmdline_args.repetitions
 
 
-  invoc_cfg = InvocationConfiguration(path_to_config, compile_time_filter, pira_iters, num_reps, hybrid_filter_iters)
+  invoc_cfg = InvocationConfiguration(path_to_config, pira_dir, compile_time_filter, pira_iters, num_reps, hybrid_filter_iters)
 
   return invoc_cfg
 
@@ -135,8 +137,8 @@ def main(arguments) -> None:
   home_dir = U.get_cwd()
   U.set_home_dir(home_dir)
 
-  # FIXME the user should set this in config
-  U.make_dir('/tmp/pira-' + getpass.getuser())
+  U.make_dir(invoc_cfg.get_pira_dir())
+  BackendDefaults(invoc_cfg)
 
   try:
     if arguments.config_version is 1:

--- a/pira.py
+++ b/pira.py
@@ -41,6 +41,11 @@ group.add_argument(
     '--extrap-dir', help='The base directory where extra-p folder structure is placed', type=str, default='')
 group.add_argument('--extrap-prefix', help='The prefix in extra-p naming scheme', type=str)
 
+# CSV Export options
+csv_group = parser.add_argument_group('CSV Export Options')
+csv_group.add_argument('--csv-dir', help='Export runtime measurements as CSV files to the specified directory', type=str, default='')
+csv_group.add_argument('--csv-dialect', help='The dialect the CSV file is written in. Possible values: excel, excel_tab, unix; defaults to unix', type=str, default='unix')
+
 # Experimental options - even for research software they are experimental
 experimental_group = parser.add_argument_group('Experimental Options - experimental even for research software')
 experimental_group.add_argument('--hybrid-filter-iters', help='Do compiletime-filtering after x iterations', default=0, type=int)

--- a/pira.py
+++ b/pira.py
@@ -7,6 +7,7 @@ Description: This is PIRA.
 __version__ = '0.2.0'
 
 import argparse
+import os
 import lib.Logging as log
 import lib.Pira as pira
 
@@ -21,6 +22,9 @@ parser = argparse.ArgumentParser(prog='PIRA')
 
 # --- Required arguments section
 parser.add_argument('config', help='The configuration json file.')
+
+# -- Pira folder option
+parser.add_argument('--pira-dir', help='The directory which stores PIRA runtime files', type=str, default=os.path.join(os.path.expanduser('~'), '.pira'))
 
 # --- Pira "mode" options
 parser.add_argument('--config-version', help='Which config file version to use', choices=[1, 2], default=2, type=int)

--- a/test/unit/ExporterTest.py
+++ b/test/unit/ExporterTest.py
@@ -7,6 +7,8 @@ Description: Unit test for Exporter module.
 import unittest
 
 import lib.Exporter as E
+import lib.Measurement as M
+import os
 
 class TestCSVExporter(unittest.TestCase):
   
@@ -65,3 +67,34 @@ class TestCSVExporter(unittest.TestCase):
     exporter.add_new_export('a', [1])
     exporter.add_export('a', [2])
     self.assertEqual(exporter._exports['a'], [1, 2])
+
+class TestRunResultExporter(unittest.TestCase):
+  def test_init(self):
+    rre = E.RunResultExporter()
+    self.assertIsNotNone(rre)
+
+  def test_add_row(self):
+    rre = E.RunResultExporter()
+    rr = M.RunResult(1,1)
+    rr.add_values(2,2)
+    rre.add_row("test", rr)
+    self.assertEqual(len(rre.rows), 1)
+    self.assertEqual(len(rre.rows[0]), 5)
+    self.assertEqual(rre.rows[0][0], "test")
+    self.assertEqual(rre.rows[0][1], 1)
+    self.assertEqual(rre.rows[0][2], 1)
+    self.assertEqual(rre.rows[0][3], 2)
+    self.assertEqual(rre.rows[0][4], 2)
+    self.assertEqual(rre.width, 5)
+
+  def test_export(self):
+    rre = E.RunResultExporter()
+    rr = M.RunResult(1, 1)
+    rr.add_values(2, 2)
+    rre.add_row("test", rr)
+    rre.export("test_file")
+    with open("test_file", "r") as tf:
+      data = tf.read()
+      expected_data = '"Type of Run","Accumulated Runtime","Number of Runs","Accumulated Runtime","Number of Runs"\n"test","1","1","2","2"\n'
+      self.assertEqual(data, expected_data)
+    os.remove("test_file")

--- a/test/unit/RunnerFactoryTest.py
+++ b/test/unit/RunnerFactoryTest.py
@@ -11,11 +11,12 @@ from lib.ProfileSink import NopSink, ExtrapProfileSink, PiraOneProfileSink
 from lib.ArgumentMapping import CmdlineLinearArgumentMapper
 
 import unittest
-
+import os
 
 class TestRunnerFactory(unittest.TestCase):
   def setUp(self):
     self._path_to_config = '/tmp'
+    self._pira_dir = os.path.join(os.path.expanduser('~'), '.pira')
     self._compile_t_filter = True
     self._pira_iters = 3
     self._num_reps = 4


### PR DESCRIPTION
defaults to `.pira` in user home folder, e.g., `/home/user/.pira/`